### PR TITLE
fix terran goliath production

### DIFF
--- a/src/terran/attacks/mech.pyai
+++ b/src/terran/attacks/mech.pyai
@@ -3,7 +3,7 @@ use_attack_vs(Terran, Protoss, Zerg)
 if owned(Machine Shop):
     train(6, Siege Tank)
 
-    if enemyownsairtech():
+    if enemyownsair():
         if owned(Armory):
             attack_train(8, Goliath)
 


### PR DESCRIPTION
When I play TvT AI keeps making a lot of goliaths even if I don't make any air units but ground units only. I build Starport only because I need level 2/3 upgrades in Armory.