### PR TITLE
Protoss AI does not make observers against Terran mines

### DIFF
--- a/src/protoss/managers/tech_manager.pyai
+++ b/src/protoss/managers/tech_manager.pyai
@@ -7,6 +7,10 @@ if enemyowns(Nexus):
     build_finish(1, Robotics Facility)
     build_start(1, Robotics Support Bay)
 
+if enemyowns(Command Center):
+    build_finish(1, Observatory)
+    train(2, Observer)
+
 build_start(3, Gateway)
 build_finish(4, Gateway)
 


### PR DESCRIPTION
Observers are build only in town manager and only if enemyownscloaked. I don't make cloacked terran units, so this leads to no detectors against Terran mines. I added observer build in tech manager.

Please check and fix if needed. Thank you.
